### PR TITLE
added new plugin for Joi creation from model

### DIFF
--- a/pluginRegistry.json
+++ b/pluginRegistry.json
@@ -127,6 +127,14 @@
 			"authorRepo": "https://github.com/hackolade",
 			"description": "Hackolade plugin for Neo4j",
 			"repository": "https://github.com/hackolade/neo4j"
+		},
+		{
+			"name": "Joi",
+			"target": "JOI",
+			"author": "Robert Al Malak",
+			"authorRepo": "https://github.com/Qwin",
+			"description": "Hackolade plugin for Joi",
+			"repository": "https://github.com/Qwin/Joi"
 		}
 	]
 }


### PR DESCRIPTION
Joi plugin for hackolade. 

Note that this plugin has custom types where one type is document instead of object. This is mainly done to keep backwards compat with models created by JSON plugin. (by changing the targetType to Joi in the model file you can open it within the plugins context)